### PR TITLE
checkout `inputs.ref` or `github.sha`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.version }}
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v27
     - shell: bash
       run: |
         echo null > metadata.err

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.version }}
     - uses: cachix/install-nix-action@v22

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.version }}
+        ref: ${{ inputs.ref || github.sha }}
     - uses: cachix/install-nix-action@v27
     - shell: bash
       run: |


### PR DESCRIPTION
instead of checking out the `version` - not something guaranteed to be a valid git reference - we can checkout the passed `ref` or `sha`

also updated the versions of our deps :p
