### PR TITLE
fix: Unsupported tarball input attribute `lastModified`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.version }}
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v27
     - shell: bash
       run: |
         echo null > metadata.err


### PR DESCRIPTION
Using the version on "main" caused the following error:

<img width="919" alt="image" src="https://github.com/user-attachments/assets/63a0d7fd-8bfd-4afc-ac4c-3550267b5e33">

Upon closer inspection, the following command yields an error:

```
> nix flake metadata --json
error: unsupported tarball input attribute 'lastModified'
```

The issue is resolved by upgrading the version of "install-nix-action".